### PR TITLE
Fixes for llvm.org

### DIFF
--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -4948,16 +4948,6 @@ body {
 
 ================================
 
-circt.llvm.org
-mlir.llvm.org
-
-CSS
-header {
-    background: none !important;
-}
-
-================================
-
 circuit-diagram.org
 
 INVERT
@@ -14385,6 +14375,18 @@ td.c {
 }
 pre[itemprop="articleBody"] a {
     color: ${lightblue};
+}
+
+================================
+
+llvm.org
+*.llvm.org
+
+CSS
+header,
+.www_sectiontitle,
+.www_sidebar {
+    background: none !important;
 }
 
 ================================

--- a/src/config/dynamic-theme-fixes.config
+++ b/src/config/dynamic-theme-fixes.config
@@ -5960,8 +5960,42 @@ INVERT
 .crowdin-navbar__logo
 svg.logo-icon-projects
 .file_type.file_folder.file_branch
-#master-loader > .master-loader-logo
-#master-loader-progress.bar
+.static-icon
+.static-icon-back
+.static-icon-next
+.static-icon-dots-v
+.static-icon-menu
+.static-icon-filter
+.static-icon-case-sensitive
+.static-icon-search-full-match
+.static-icon-search-strict
+.static-icon-comfortable-view
+.static-icon-pane-opened-left
+.static-icon-pane-opened-right
+.static-icon-command-palette
+.static-icon-keyboard
+.static-icon-cog
+.static-icon-file
+.static-icon-web
+.static-icon-inbox
+.static-icon-view
+.static-icon-circled-help
+.file_type
+.static-icon-comments
+.static-icon-tms
+.static-icon-terms
+.static-icon-file-context
+.static-icon-plus
+.static-icon-chevron-right
+.static-icon-pin
+.static-icon-copy-source
+.static-icon-trash
+.static-icon-textbox
+
+CSS
+.main-menu-wrapper {
+    background-color: var(--darkreader-neutral-background) !important;
+}
 
 ================================
 


### PR DESCRIPTION
Remove background images from areas where they make text unreadable, merge the *.llvm.org rules already present into general llvm.org rules.